### PR TITLE
apb_regs: Tool compatibility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- Improve tool compatibility by explicitly annotating the type of a `struct` assignment.
+- Set the initial value of the registers as soon as the reset is released, rather than as reset
+  value, because driving the reset value from an input signal is potentially unsafe.
 
 
 ## 0.2.0 - 2020-03-13


### PR DESCRIPTION
- Some tools require explicit hints on the type
  for the structured assignment.
- Reset values driven from signals are generally considered
  unsafe. A tiny FSM initializes these values.