### PR TITLE
Add additional VIP classes

### DIFF
--- a/src/apb_test.sv
+++ b/src/apb_test.sv
@@ -22,14 +22,14 @@ package apb_test;
     rand logic [DATA_WIDTH-1:0]   pwdata = '0;
     rand logic [STRB_WIDTH-1:0]   pstrb  = '0;
     rand logic                    pwrite = 1'b1;
-  endclass; // apb_request
+  endclass;
 
   class apb_response #(
     parameter DATA_WIDTH = 32'd32
   );
     rand logic [DATA_WIDTH-1:0] prdata  = '0;
     rand logic                  pslverr = 1'b0;
-  endclass; // apb_read_request
+  endclass;
 
   // Simple APB driver with thread-safe read and write functions
   class apb_driver #(
@@ -138,7 +138,7 @@ package apb_test;
       apb.psel    <= #TA 1'b0;
       apb.penable <= #TA 1'b0;
       lock.put();
-    endtask // write
+    endtask
 
     // Wait for incoming apb request
     task recv_request (
@@ -153,7 +153,7 @@ package apb_test;
       request.pwrite = apb.pwrite;
       request.pstrb  = apb.pstrb;
       cycle_end();
-    endtask // recv_requests
+    endtask
 
     // Acknowledge incoming APB write request (assert pready).
     task send_write_ack();
@@ -175,7 +175,7 @@ package apb_test;
       apb.pslverr   <= #TA 0;
     endtask
 
-  endclass // apb_driver
+  endclass
 
   class apb_rand_slave #(
     // APB interface parmeters
@@ -214,7 +214,7 @@ package apb_test;
       this.request_queue  = new;
       this.response_queue = new;
       this.reset();
-    endfunction // new
+    endfunction
 
     function reset();
       drv.reset_slave();
@@ -255,7 +255,7 @@ package apb_test;
       handle_requests();
     endtask
 
-  endclass // apb_rand_slave
+  endclass
 
   class apb_rand_master #(
     // APB interface parmeters
@@ -295,11 +295,11 @@ package apb_test;
       this.request_queue  = new;
       this.response_queue = new;
       this.reset();
-    endfunction // new
+    endfunction
 
     function reset();
       drv.reset_master();
-    endfunction // reset
+    endfunction
 
     // TODO: The `rand_wait` task exists in `rand_verif_pkg`, but that task cannot be called with
     // `this.drv.apb.clk_i` as `clk` argument.  What is the syntax getting an assignable reference?
@@ -336,7 +336,7 @@ package apb_test;
     task automatic run(input int unsigned n_request);
       $info("Run apb_rand_master for %0d transactions", n_request);
       send_requests(n_request);
-    endtask // run
+    endtask
 
   endclass
 endpackage

--- a/src/apb_test.sv
+++ b/src/apb_test.sv
@@ -145,7 +145,8 @@ package apb_test;
       output apb_request_t request
     );
       cycle_start();
-      while (apb.psel != 1 && apb.penable != 1) begin cycle_end(); cycle_start(); end
+      while (!apb.psel) begin cycle_end(); cycle_start(); end
+      while (!apb.penable) begin cycle_end(); cycle_start(); end
       request        = new;
       request.paddr  = apb.paddr;
       request.pwdata = apb.pwdata;
@@ -180,7 +181,6 @@ package apb_test;
     // APB interface parmeters
     parameter int unsigned ADDR_WIDTH = 32'd32,
     parameter int unsigned DATA_WIDTH = 32'd32,
-    // Stimuli application and test time
     // Stimuli application and test time
     parameter time  TA = 0ps,
     parameter time  TT = 0ps,
@@ -239,7 +239,7 @@ package apb_test;
         automatic logic rand_success;
         drv.recv_request(request);
         request_queue.put(request);
-        if (request.pwrite == 1) begin
+        if (request.pwrite) begin
           rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES);
           drv.send_write_ack();
         end else begin
@@ -253,7 +253,7 @@ package apb_test;
 
     task run();
       handle_requests();
-    endtask : run // run
+    endtask
 
   endclass // apb_rand_slave
 
@@ -261,7 +261,6 @@ package apb_test;
     // APB interface parmeters
     parameter int unsigned ADDR_WIDTH = 32'd32,
     parameter int unsigned DATA_WIDTH = 32'd32,
-    // Stimuli application and test time
     // Stimuli application and test time
     parameter time         TA = 0ps,
     parameter time         TT = 0ps,
@@ -312,7 +311,7 @@ package apb_test;
       };
       assert (rand_success) else $error("Failed to randomize wait cycles!");
       repeat (cycles) @(posedge this.drv.apb.clk_i);
-    endtask : rand_wait // rand_wait
+    endtask
 
     task automatic send_requests(input int unsigned n_requests);
       automatic apb_request_t request = new;
@@ -323,8 +322,8 @@ package apb_test;
         rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
         rand_success       = request.randomize(); assert(rand_success);
         request_queue.put(request);
-        if (request.pwrite == 1'b1) begin
-          $info("Sending write reqeust with addr: %h, pstrb: %b and pwdata: %h", request.paddr, request.pstrb, request.pwdata);
+        if (request.pwrite) begin
+          $info("Sending write request with addr: %h, pstrb: %b and pwdata: %h", request.paddr, request.pstrb, request.pwdata);
           drv.write(request.paddr, request.pwdata, request.pstrb, write_err);
         end else begin
           $info("Sending read request with addr: %h...", request.paddr);

--- a/src/apb_test.sv
+++ b/src/apb_test.sv
@@ -12,6 +12,25 @@
 // Test infrastructure for APB interfaces
 package apb_test;
 
+  class apb_request #(
+    parameter ADDR_WIDTH = 32'd32,
+    parameter DATA_WIDTH = 32'd32
+  );
+    localparam STRB_WIDTH = cf_math_pkg::ceil_div(DATA_WIDTH, 8);
+
+    rand logic [ADDR_WIDTH-1:0]   paddr  = '0;
+    rand logic [DATA_WIDTH-1:0]   pwdata = '0;
+    rand logic [STRB_WIDTH-1:0]   pstrb  = '0;
+    rand logic                    pwrite = 1'b1;
+  endclass; // apb_request
+
+  class apb_response #(
+    parameter DATA_WIDTH = 32'd32
+  );
+    rand logic [DATA_WIDTH-1:0] prdata  = '0;
+    rand logic                  pslverr = 1'b0;
+  endclass; // apb_read_request
+
   // Simple APB driver with thread-safe read and write functions
   class apb_driver #(
     parameter int unsigned ADDR_WIDTH = 32'd32, // APB4 address width
@@ -23,6 +42,8 @@ package apb_test;
     typedef logic [ADDR_WIDTH-1:0] addr_t;
     typedef logic [DATA_WIDTH-1:0] data_t;
     typedef logic [STRB_WIDTH-1:0] strb_t;
+    typedef apb_request #(.ADDR_WIDTH(ADDR_WIDTH), .DATA_WIDTH(DATA_WIDTH)) apb_request_t;
+    typedef apb_response #(.DATA_WIDTH(DATA_WIDTH)) apb_response_t;
     virtual APB_DV #(
       .ADDR_WIDTH(ADDR_WIDTH),
       .DATA_WIDTH(DATA_WIDTH)
@@ -117,8 +138,206 @@ package apb_test;
       apb.psel    <= #TA 1'b0;
       apb.penable <= #TA 1'b0;
       lock.put();
+    endtask // write
+
+    // Wait for incoming apb request
+    task recv_request (
+      output apb_request_t request
+    );
+      cycle_start();
+      while (apb.psel != 1 && apb.penable != 1) begin cycle_end(); cycle_start(); end
+      request        = new;
+      request.paddr  = apb.paddr;
+      request.pwdata = apb.pwdata;
+      request.pwrite = apb.pwrite;
+      request.pstrb  = apb.pstrb;
+      cycle_end();
+    endtask // recv_requests
+
+    // Acknowledge incoming APB write request (assert pready).
+    task send_write_ack();
+      apb.pready <= #TA 1;
+      cycle_end();
+      apb.pready <= #TA 0;
     endtask
 
-  endclass
+    // Send response for incoming APB read request acknowledging the request (assert pready).
+    task send_read_response (
+      input apb_response_t response
+    );
+      apb.pready <= #TA 1;
+      apb.prdata <= #TA response.prdata;
+      apb.pslverr <= #TA response.pslverr;
+      cycle_end();
+      apb.pready    <= #TA 0;
+      apb.prdata    <= #TA '0;
+      apb.pslverr   <= #TA 0;
+    endtask
 
+  endclass // apb_driver
+
+  class apb_rand_slave #(
+    // APB interface parmeters
+    parameter int unsigned ADDR_WIDTH = 32'd32,
+    parameter int unsigned DATA_WIDTH = 32'd32,
+    // Stimuli application and test time
+    // Stimuli application and test time
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps,
+    // Upper and lower bounds on wait states on Response (pready)
+    parameter int   RESP_MIN_WAIT_CYCLES = 0,
+    parameter int   RESP_MAX_WAIT_CYCLES = 20
+  );
+
+    typedef apb_test::apb_driver #(
+      .ADDR_WIDTH(ADDR_WIDTH), .DATA_WIDTH(DATA_WIDTH), .TA(TA), .TT(TT)
+    ) apb_driver_t;
+
+    typedef apb_driver_t::addr_t addr_t;
+    typedef apb_driver_t::data_t data_t;
+    typedef apb_driver_t::strb_t strb_t;
+
+    typedef apb_driver_t::apb_request_t apb_request_t;
+    typedef apb_driver_t::apb_response_t apb_response_t;
+
+    apb_driver_t 	    drv;
+    mailbox #(apb_request_t) request_queue;
+    mailbox #(apb_response_t) response_queue;
+
+    function new(
+      virtual APB_DV #(
+        .ADDR_WIDTH(ADDR_WIDTH),
+        .DATA_WIDTH(DATA_WIDTH)
+      ) apb
+    );
+      this.drv            = new(apb);
+      this.request_queue  = new;
+      this.response_queue = new;
+      this.reset();
+    endfunction // new
+
+    function reset();
+      drv.reset_slave();
+    endfunction
+
+    // TODO: The `rand_wait` task exists in `rand_verif_pkg`, but that task cannot be called with
+    // `this.drv.apb.clk_i` as `clk` argument.  What is the syntax getting an assignable reference?
+    task automatic rand_wait(input int unsigned min, max);
+      int unsigned rand_success, cycles;
+      rand_success = std::randomize(cycles) with {
+        cycles >= min;
+        cycles <= max;
+      };
+      assert (rand_success) else $error("Failed to randomize wait cycles!");
+      repeat (cycles) @(posedge this.drv.apb.clk_i);
+    endtask : rand_wait
+
+    task handle_requests();
+      forever begin
+        automatic apb_request_t request;
+        automatic apb_response_t read_response = new;
+        automatic logic rand_success;
+        drv.recv_request(request);
+        request_queue.put(request);
+        if (request.pwrite == 1) begin
+          rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES);
+          drv.send_write_ack();
+        end else begin
+          rand_success = read_response.randomize(); assert(rand_success);
+          response_queue.put(read_response);
+          rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES);
+          drv.send_read_response(read_response);
+        end
+      end
+    endtask : handle_requests // recv_requests
+
+    task run();
+      handle_requests();
+    endtask : run // run
+
+  endclass // apb_rand_slave
+
+  class apb_rand_master #(
+    // APB interface parmeters
+    parameter int unsigned ADDR_WIDTH = 32'd32,
+    parameter int unsigned DATA_WIDTH = 32'd32,
+    // Stimuli application and test time
+    // Stimuli application and test time
+    parameter time         TA = 0ps,
+    parameter time         TT = 0ps,
+    // Upper and lower bounds on wait cycles on request channel
+    parameter int          REQ_MIN_WAIT_CYCLES = 0,
+    parameter int          REQ_MAX_WAIT_CYCLES = 20
+  );
+
+    typedef apb_test::apb_driver #(
+      .ADDR_WIDTH(ADDR_WIDTH), .DATA_WIDTH(DATA_WIDTH), .TA(TA), .TT(TT)
+    ) apb_driver_t;
+
+    typedef apb_driver_t::addr_t addr_t;
+    typedef apb_driver_t::data_t data_t;
+    typedef apb_driver_t::strb_t strb_t;
+
+    typedef apb_driver_t::apb_request_t apb_request_t;
+    typedef apb_driver_t::apb_response_t apb_response_t;
+
+    apb_driver_t 	    drv;
+    mailbox #(apb_request_t) request_queue;
+    mailbox #(apb_response_t) response_queue;
+
+
+    function new(
+      virtual APB_DV #(
+        .ADDR_WIDTH(ADDR_WIDTH),
+        .DATA_WIDTH(DATA_WIDTH)
+      ) apb
+    );
+      this.drv            = new(apb);
+      this.request_queue  = new;
+      this.response_queue = new;
+      this.reset();
+    endfunction // new
+
+    function reset();
+      drv.reset_master();
+    endfunction // reset
+
+    // TODO: The `rand_wait` task exists in `rand_verif_pkg`, but that task cannot be called with
+    // `this.drv.apb.clk_i` as `clk` argument.  What is the syntax getting an assignable reference?
+    task automatic rand_wait(input int unsigned min, max);
+      int unsigned rand_success, cycles;
+      rand_success = std::randomize(cycles) with {
+        cycles >= min;
+        cycles <= max;
+      };
+      assert (rand_success) else $error("Failed to randomize wait cycles!");
+      repeat (cycles) @(posedge this.drv.apb.clk_i);
+    endtask : rand_wait // rand_wait
+
+    task automatic send_requests(input int unsigned n_requests);
+      automatic apb_request_t request = new;
+      automatic apb_response_t response = new;
+      automatic logic write_err;
+      automatic logic rand_success;
+      repeat (n_requests) begin
+        rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
+        rand_success       = request.randomize(); assert(rand_success);
+        request_queue.put(request);
+        if (request.pwrite == 1'b1) begin
+          $info("Sending write reqeust with addr: %h, pstrb: %b and pwdata: %h", request.paddr, request.pstrb, request.pwdata);
+          drv.write(request.paddr, request.pwdata, request.pstrb, write_err);
+        end else begin
+          $info("Sending read request with addr: %h...", request.paddr);
+          drv.read(request.paddr, response.prdata, response.pslverr);
+          response_queue.put(response);
+        end
+      end
+    endtask : send_requests
+
+    task automatic run(input int unsigned n_request);
+      $info("Run apb_rand_master for %0d transactions", n_request);
+      send_requests(n_request);
+    endtask // run
+
+  endclass
 endpackage


### PR DESCRIPTION
This commit adds two new apb vip classes to apb_test:
apb_rand_slave and apb_rand_master

They are implemented similar in style like the ones present in the https://github.com/pulp-platform/axi project and perform random transactions/responses on the provided APB_DV buses. In contrast to the ones in the axi project, they use SV mailboxes to record all incoming and outgoing transactions/read responses so an external TB can probe them in a threadsafe manner. Both classes are tested in a small TB for a new apb_cdc module that will be contributed in a follow-up PR.