### PR TITLE
Fix package imports and add core description file

### DIFF
--- a/apb.core
+++ b/apb.core
@@ -1,0 +1,59 @@
+CAPI=2:
+
+name: pulp-platform.org::apb:0.2.4
+description: Implementation of the AMBA APB4 protocol, version 2.0, developed as part of the PULP platform at ETH Zurich
+
+filesets:
+  rtl:
+    files:
+      - include/apb/assign.svh : {is_include_file: true, include_path: include}
+      - include/apb/typedef.svh: {is_include_file: true, include_path: include}
+      - src/apb_pkg.sv
+      - src/apb_intf.sv
+      - src/apb_err_slv.sv
+      - src/apb_regs.sv
+      - src/apb_cdc.sv
+      - src/apb_demux.sv
+    file_type: systemVerilogSource
+    depend:
+      - ">=pulp-platform.org::common_cells:1.16.2"
+
+  sim:
+    files:
+      - src/apb_test.sv
+      - test/tb_apb_regs.sv
+      - test/tb_apb_cdc.sv
+      - test/tb_apb_demux.sv
+    file_type: systemVerilogSource
+    depend: [pulp-platform.org::common_verification]
+
+  synth:
+    files:
+      - test/synth_bench.sv : {file_type: systemVerilogSource}
+
+targets:
+  default:
+    filesets: [rtl]
+
+  synth:
+    filesets: [rtl, synth]
+    toplevel: synth_bench
+
+  tb_apb_regs: &tb
+    description: Testbench for apb_regs
+    filesets: [rtl, sim]
+    flow: sim
+    flow_options:
+      tool: verilator
+      vlogan_options: [-timescale=1ns/1ps]
+    toplevel: tb_apb_regs
+
+  tb_apb_demux:
+    description: Testbench for apb_demux
+    <<: *tb
+    toplevel: tb_apb_demux
+
+  tb_apb_cdc:
+    description: Testbench for apb_cdc
+    <<: *tb
+    toplevel: tb_apb_demux

--- a/src/apb_intf.sv
+++ b/src/apb_intf.sv
@@ -10,7 +10,9 @@
 // specific language governing permissions and limitations under the License.
 
 // An APB4 (v2.0) interface
-interface APB #(
+interface APB
+  import cf_math_pkg::*;
+#(
   parameter int unsigned ADDR_WIDTH = 32'd32,
   parameter int unsigned DATA_WIDTH = 32'd32
 );
@@ -43,7 +45,9 @@ interface APB #(
 endinterface
 
 // A clocked APB4 (v2.0) interface for use in design verification
-interface APB_DV #(
+interface APB_DV
+  import cf_math_pkg::*;
+#(
   parameter int unsigned ADDR_WIDTH = 32'd32,
   parameter int unsigned DATA_WIDTH = 32'd32
 ) (

--- a/src/apb_regs.sv
+++ b/src/apb_regs.sv
@@ -218,6 +218,9 @@ module apb_regs_intf #(
   input  reg_data_t [NO_APB_REGS-1:0] reg_init_i,  // initalisation value for the registers
   output reg_data_t [NO_APB_REGS-1:0] reg_q_o
 );
+
+  import cf_math_pkg::*;
+
   localparam int unsigned APB_STRB_WIDTH = cf_math_pkg::ceil_div(APB_DATA_WIDTH, 8);
   typedef logic [APB_DATA_WIDTH-1:0] apb_data_t;
   typedef logic [APB_STRB_WIDTH-1:0] apb_strb_t;

--- a/src/apb_test.sv
+++ b/src/apb_test.sv
@@ -12,6 +12,8 @@
 // Test infrastructure for APB interfaces
 package apb_test;
 
+  import cf_math_pkg::*;
+
   class apb_request #(
     parameter ADDR_WIDTH = 32'd32,
     parameter DATA_WIDTH = 32'd32


### PR DESCRIPTION
cf_math_pkg::ceil_div is used in several places without first importing the packages. This only works if apb is compiled in the same compilation unit than common_cells. Explicitly importing allows different compilation units.

Also adds a FuseSoC core description file for the APB core.